### PR TITLE
RAP-183 Add logging to the scheduler

### DIFF
--- a/cron_sentry/runner.py
+++ b/cron_sentry/runner.py
@@ -1,6 +1,6 @@
 import sys
 from getpass import getuser
-from os import getenv, path, SEEK_END
+from os import getenv, path, SEEK_END, environ
 from raven import Client
 from raven.transport import HTTPTransport
 from subprocess import call
@@ -35,7 +35,7 @@ parser = ArgumentParser(
 parser.add_argument(
     '--dsn',
     metavar='SENTRY_DSN',
-    default=getenv('SENTRY_DSN'),
+    default=environ['SENTRY_DSN'], # if there isn't a SENTRY_DSN explicitly set to nothing then we need to fail
     help='Sentry server address',
 )
 

--- a/cron_sentry/runner.py
+++ b/cron_sentry/runner.py
@@ -134,10 +134,13 @@ class CommandReporter(object):
                     send_failed = self.report_fail(exit_status, last_lines_stdout, last_lines_stderr, elapsed)
 
                 if send_failed:
-                    stdout.seek(0)
                     stderr.seek(0)
-                    sys.stdout.write(stdout.read())
-                    sys.stderr.write(stderr.read())
+                    error = stderr.read()
+                    error += "\nError running {}, but failed to send to Sentry".format(self.command)
+                    sys.stderr.write(error)
+
+                stdout.seek(0)
+                sys.stdout.write(stdout.read())
 
                 return exit_status
 


### PR DESCRIPTION
so, gotten rid of cron-sentry.conf 
if there's no variable set, fails to even run
use it in the command line works
use it in the env file, it works
if the variable is set to empty string errors into the log file
